### PR TITLE
Fix ambiguous call between winstr.$ and dollars.$

### DIFF
--- a/winim/winstr.nim
+++ b/winim/winstr.nim
@@ -872,7 +872,7 @@ proc `$$`*[I](a: array[I, char]|array[I, WCHAR]|ptr array[I, char]|ptr array[I, 
   elif a is ptr array[I, char]:
     cast[string](`ANSI->string`(cast[ptr char](a), a[].len, alloc=false))
   else:
-    $a
+    winstr.`$`(a)
 
 proc `+$$`*(s: string|cstring|ptr char|wstring|mstring|LPWSTR|BSTR|char|WCHAR): wstring {.inline.} =
   ## Convert any stringable type to wstring.


### PR DESCRIPTION
Error:

```
../../winim/winim/winstr.nim(876, 5) Error: ambiguous call; both winstr.$(a: array[I, char] or array[I, WCHAR] or ptr array[I, char] or ptr array[I, WCHAR]) [declared in ../../winim/winim/winstr.nim(777, 6)] and dollars.$(x: array[IDX, T]) [declared in ../../Nim/lib/system/dollars.nim(148, 8)] match for: (array[0..259, WCHAR])
```